### PR TITLE
[fix] 修复多机器人环境下重复触发连接配置的问题 (#44)

### DIFF
--- a/src/ui/page/bot_list_page/bot_widget/__init__.py
+++ b/src/ui/page/bot_list_page/bot_widget/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # 标准库导入
+from enum import Enum
 from typing import Any, Dict, Optional
 
 # 第三方库导入
@@ -7,7 +8,7 @@ import psutil
 from qfluentwidgets import PushButton, ToolTipFilter, TransparentToolButton
 from qfluentwidgets.common import FluentIcon
 from qfluentwidgets.components import PrimaryPushButton, SegmentedWidget, ToolButton
-from PySide6.QtCore import QProcess, QRegularExpression, Qt, Slot
+from PySide6.QtCore import QProcess, QRegularExpression, Qt, Signal, Slot
 from PySide6.QtGui import QTextCursor
 from PySide6.QtWidgets import QHBoxLayout, QStackedWidget, QVBoxLayout, QWidget
 
@@ -38,6 +39,8 @@ from src.ui.page.bot_list_page.signal_bus import bot_list_page_signal_bus
 
 class BotWidget(QWidget):
     """机器人配置卡片控件，包含设置、日志等标签页"""
+
+    choose_connect_type_signal = Signal(Enum)
 
     def __init__(self, config: Config) -> None:
         """初始化机器人控件
@@ -122,7 +125,7 @@ class BotWidget(QWidget):
         self.delete_config_button.clicked.connect(self._on_delete_button)
         self.return_button.clicked.connect(self._on_return_button)
         self.add_connect_config_button.clicked.connect(self._on_add_connect_config_button_clicked)
-        bot_list_page_signal_bus.choose_connect_type_signal.connect(self._on_show_type_dialog)
+        self.choose_connect_type_signal.connect(self._on_show_type_dialog)
 
         # 隐藏按钮
         self.stop_button.hide()
@@ -297,7 +300,7 @@ class BotWidget(QWidget):
         # 项目内模块导入
         from src.ui.window.main_window import MainWindow
 
-        ChooseConfigTypeDialog(MainWindow()).exec()
+        ChooseConfigTypeDialog(MainWindow(), self.choose_connect_type_signal).exec()
 
     def _on_show_type_dialog(self, connect_type: ConnectType) -> None:
         """显示连接类型选择对话框槽函数

--- a/src/ui/page/bot_list_page/bot_widget/meg_box.py
+++ b/src/ui/page/bot_list_page/bot_widget/meg_box.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide6.QtCore import QObject, Slot
+from PySide6.QtCore import QObject, Signal
 
 # 项目内模块导入
 from src.ui.page.add_page.enum import ConnectType
@@ -9,13 +9,14 @@ from src.ui.page.bot_list_page.signal_bus import bot_list_page_signal_bus
 
 class ChooseConfigTypeDialog(OldChooseConfigTypeDialog):
 
-    def __init__(self, parent: QObject) -> None:
+    def __init__(self, parent: QObject, signal: Signal) -> None:
         super().__init__(parent=parent)
+        self.signal = signal
 
     def accept(self) -> None:
         """重写 accept 方法, 选择配置类型后发送信号"""
 
         if (id := self.button_group.checkedId()) != -1:
-            bot_list_page_signal_bus.choose_connect_type_signal.emit(list(ConnectType)[id])
+            self.signal.emit(list(ConnectType)[id])
 
         self.close()

--- a/src/ui/page/bot_list_page/signal_bus.py
+++ b/src/ui/page/bot_list_page/signal_bus.py
@@ -11,7 +11,6 @@ class BotListPageSignalBus(QObject):
 
     add_widget_view_change_signal = Signal(int)  # 添加页面视图切换信号, 带切换的索引
     add_connect_config_button_signal = Signal()  # 添加网络配置按钮点击信号
-    choose_connect_type_signal = Signal(Enum)  # 选择连接类型信号, 带连接类型的字符串
     remove_card_signal = Signal(QObject)  # 删除卡片信号, 带卡片
 
 


### PR DESCRIPTION
## 描述
修复了在多机器人环境下添加连接配置时重复触发的问题。当使用多个机器人时，添加连接配置会错误地触发多次，导致出现多个添加窗口。

## 关联Issue
Fixes #44

## 改动内容
- 移除了总线机制,改为一对一

## 测试情况
- ✅ 在多机器人环境下测试添加连接配置功能
- ✅ 验证单个机器人添加配置正常
- ✅ 确认修复后不会出现重复弹窗
- ✅ 测试各机器人配置的独立性和正确性

## Sourcery 总结

通过将共享信号总线替换为部件专属信号，修复多 Bot 环境中重复的连接配置对话框，确保每个 Bot 实例管理自己的对话框。

Bug 修复:
- 通过从共享信号总线迁移到部件专属信号，防止在多 Bot 设置中出现重复的连接配置对话框

增强:
- 移除全局的 `choose_connect_type_signal`，并更新 `BotWidget` 和 `ChooseConfigTypeDialog` 以使用新的实例专属信号
- 将部件专属信号传递到配置对话框中，而不是使用全局总线

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix duplicate connection configuration dialogs in multi-bot environments by replacing the shared signal bus with per-widget signals, ensuring each bot instance manages its own dialog.

Bug Fixes:
- Prevent duplicate connection config dialogs in multi-bot setups by migrating from a shared signal bus to per-widget signals

Enhancements:
- Remove global choose_connect_type_signal and update BotWidget and ChooseConfigTypeDialog to use the new per-instance signal
- Pass the widget-specific signal into the configuration dialog instead of using the global bus

</details>