### PR TITLE
[refactor] 使用 QRunnable 重构安装模块和下载的线程逻辑 (#50)

### DIFF
--- a/src/core/network/downloader.py
+++ b/src/core/network/downloader.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 # 第三方库导入
 import httpx
-from PySide6.QtCore import QThread, QUrl, Signal
+from PySide6.QtCore import QObject, QRunnable, QUrl, Signal
 
 # 项目内模块导入
 from src.core.network.urls import Urls
@@ -13,7 +13,7 @@ from src.core.utils.path_func import PathFunc
 from src.ui.page.unit_page.status import ButtonStatus, ProgressRingStatus
 
 
-class DownloaderBase(QThread):
+class DownloaderBase(QObject, QRunnable):
     """下载器基类
 
     定义了3个信号:
@@ -37,7 +37,8 @@ class DownloaderBase(QThread):
     status_label_signal = Signal(str)
 
     def __init__(self) -> None:
-        super().__init__()
+        QObject.__init__(self)
+        QRunnable.__init__(self)
 
 
 class GithubDownloader(DownloaderBase):

--- a/src/core/utils/get_version.py
+++ b/src/core/utils/get_version.py
@@ -176,7 +176,7 @@ class GetLocalVersionRunnable(VersionRunnableBase):
                 return f"v{json.loads(f.read())['version']}"
         except FileNotFoundError:
             logger.error("获取 NapCat 版本信息失败: 文件不存在")
-            self.error_signal("获取 NapCat 版本信息失败: 文件不存在")
+            self.error_signal.emit("获取 NapCat 版本信息失败: 文件不存在")
             return None
 
     def get_qq_version(self) -> str | None:
@@ -193,7 +193,7 @@ class GetLocalVersionRunnable(VersionRunnableBase):
         except FileNotFoundError:
             # 文件不存在则返回 None
             logger.error("获取 QQ 版本信息失败: 文件不存在")
-            self.error_signal("获取 QQ 版本信息失败: 文件不存在")
+            self.error_signal.emit("获取 QQ 版本信息失败: 文件不存在")
             return None
 
     def get_ncd_version(self) -> str | None:

--- a/src/ui/page/unit_page/base.py
+++ b/src/ui/page/unit_page/base.py
@@ -56,6 +56,9 @@ class PageBase(ScrollArea):
         self.setLayout(self.h_box_layout)
         self.get_version = parent.get_version
 
+        self.local_version = None
+        self.remote_version = None
+
 
 class DisplayCard(SimpleCardWidget):
     """左侧的应用展示卡片, 包含图标、名称、状态和操作按钮"""

--- a/src/ui/page/unit_page/napcat_desktop_page.py
+++ b/src/ui/page/unit_page/napcat_desktop_page.py
@@ -3,7 +3,7 @@
 import subprocess
 import sys
 
-from PySide6.QtCore import QUrl, Slot
+from PySide6.QtCore import QThreadPool, QUrl, Slot
 from PySide6.QtGui import QDesktopServices
 
 # 项目内模块导入
@@ -99,14 +99,15 @@ class NCDPage(PageBase):
         # 项目内模块导入
         from src.core.network.downloader import GithubDownloader
 
-        self.downloader = GithubDownloader(Urls.NCD_DOWNLOAD.value)
-        self.downloader.download_progress_signal.connect(self.app_card.set_progress_ring_value)
-        self.downloader.download_finish_signal.connect(self.on_install)
-        self.downloader.status_label_signal.connect(self.app_card.set_status_text)
-        self.downloader.error_finsh_signal.connect(self.on_error_finsh)
-        self.downloader.button_toggle_signal.connect(self.app_card.switch_button)
-        self.downloader.progress_ring_toggle_signal.connect(self.app_card.switch_progress_ring)
-        self.downloader.start()
+        downloader = GithubDownloader(Urls.NCD_DOWNLOAD.value)
+        downloader.download_progress_signal.connect(self.app_card.set_progress_ring_value)
+        downloader.download_finish_signal.connect(self.on_install)
+        downloader.status_label_signal.connect(self.app_card.set_status_text)
+        downloader.error_finsh_signal.connect(self.on_error_finsh)
+        downloader.button_toggle_signal.connect(self.app_card.switch_button)
+        downloader.progress_ring_toggle_signal.connect(self.app_card.switch_progress_ring)
+
+        QThreadPool.globalInstance().start(downloader)
 
     @Slot()
     def on_install(self) -> None:


### PR DESCRIPTION
## Sourcery 总结

重构安装器和下载器的线程逻辑，以使用 QRunnable 和 QThreadPool，引入共享基类，调整信号发射，并相应地更新 UI 组件。

Bug 修复：
- 修正版本检索中 `error_signal` 的调用，改为使用 `.emit`。

增强：
- 将安装器和下载器的 `QThread` 替换为 `QObject+QRunnable`。
- 引入 `InstallBase` 和 `DownloaderBase` 基类，并分离 `execute/run` 逻辑。
- 在 UI 页面中，使用 `QThreadPool.globalInstance().start(...)` 而不是单独启动线程。
- 在基础 UI 中初始化 `local_version` 和 `remote_version`，并在没有本地版本时更新 `log_card`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor installer and downloader threading logic to use QRunnable with QThreadPool, introduce shared base classes, adjust signal emissions, and update UI components accordingly.

Bug Fixes:
- Correct error_signal invocation to use .emit in version retrieval

Enhancements:
- Replace QThread with QObject+QRunnable for installers and downloaders
- Introduce InstallBase and DownloaderBase base classes with execute/run separation
- Use QThreadPool.globalInstance().start(...) instead of individual thread starts in UI pages
- Initialize local_version and remote_version in base UI and update log_card when no local version

</details>