### PR TITLE
[feat] 添加退出提示和机器人添加限制 (#58)

### DIFF
--- a/src/core/utils/path_func.py
+++ b/src/core/utils/path_func.py
@@ -42,7 +42,7 @@ class PathFunc(metaclass=Singleton):
         # 文件字段
         self.config_path = self.config_dir_path / "config.json"
         self.bot_config_path = self.config_dir_path / "bot.json"
-        self.napcat_config_path = self.napcat_path / "config.json"
+        self.napcat_config_path = self.napcat_path / "config"
 
     def path_validator(self) -> None:
         """验证一系列路径"""

--- a/src/core/utils/path_func.py
+++ b/src/core/utils/path_func.py
@@ -42,6 +42,7 @@ class PathFunc(metaclass=Singleton):
         # 文件字段
         self.config_path = self.config_dir_path / "config.json"
         self.bot_config_path = self.config_dir_path / "bot.json"
+        self.napcat_config_path = self.napcat_path / "config.json"
 
     def path_validator(self) -> None:
         """验证一系列路径"""

--- a/src/ui/page/add_page/add_top_card.py
+++ b/src/ui/page/add_page/add_top_card.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import QHBoxLayout, QVBoxLayout, QWidget
 
 # 项目内模块导入
 from src.core.config.operate_config import check_duplicate_bot, update_config
+from src.core.utils.path_func import PathFunc
 from src.ui.components.info_bar import error_bar, success_bar
 from src.ui.components.separator import Separator
 from src.ui.page.add_page.signal_bus import add_page_singal_bus
@@ -119,6 +120,11 @@ class AddTopCard(QWidget):
     @Slot()
     def _on_add_bot_list_button(self) -> None:
         """添加到机器人列表"""
+        # 检查是否存在配置文件夹
+        if not PathFunc().napcat_config_path.exists():
+            error_bar(self.tr("配置文件夹不存在, 请检查是否安装 NapCatQQ"))
+            return
+
         # 项目内模块导入
         from src.core.config.config_model import Config
         from src.ui.page.add_page.add_widget import AddWidget

--- a/src/ui/window/main_window/title_bar.py
+++ b/src/ui/window/main_window/title_bar.py
@@ -11,7 +11,6 @@ from PySide6.QtSvg import QSvgRenderer
 
 # 项目内模块导入
 from src.core.config import cfg
-from src.core.config.config_enum import CloseActionEnum
 from src.ui.common.icon import NapCatDesktopIcon, StaticIcon
 
 if TYPE_CHECKING:
@@ -90,14 +89,7 @@ class CustomTitleBar(MSFluentTitleBar):
                     else self.window().showMaximized()
                 ),
             ),
-            "closeBtn": (
-                CloseBtn,
-                lambda: (
-                    self.window().close()
-                    if cfg.get(cfg.close_button_action) == CloseActionEnum.CLOSE
-                    else self.window().hide()
-                ),
-            ),
+            "closeBtn": (CloseBtn, self.window().close),
         }
 
         for btn_name, (btn_class, slot) in button_info.items():

--- a/src/ui/window/main_window/window.py
+++ b/src/ui/window/main_window/window.py
@@ -7,6 +7,7 @@ from PySide6.QtWidgets import QApplication
 
 # 项目内模块导入
 from src.core.config import cfg
+from src.core.config.config_enum import CloseActionEnum
 from src.core.utils.singleton import singleton
 from src.ui.common.icon import NapCatDesktopIcon
 from src.ui.page.add_page import AddWidget
@@ -116,3 +117,19 @@ class MainWindow(MSFluentWindow):
         """
         self.trayIcon = SystemTrayIcon(self)
         self.trayIcon.show()
+
+    def close(self) -> None:
+        """重写关闭事件"""
+        if cfg.get(cfg.close_button_action) == CloseActionEnum.CLOSE:
+            # 如果有机器人在线, 则提示用户关闭实例
+            if BotListWidget().get_bot_is_run():
+                # 项目内模块导入
+                from src.ui.components.message_box import AskBox
+
+                msg_box = AskBox(self.tr("无法退出"), self.tr("有机器人正在运行, 请关闭它们后再退出程序"), self)
+                msg_box.cancelButton.hide()
+                msg_box.exec()
+            else:
+                super().close()
+        else:
+            self.hide()


### PR DESCRIPTION
### 描述
实现退出应用时的运行中机器人检测提示机制，以及在添加机器人前的NapCatQQ安装状态验证。确保用户操作的安全性和规范性。

### 关联Issue
Feat #58

## Sourcery 摘要

引入用户提示和安装检查以提高机器人管理安全性

新功能:
- 当机器人仍在运行时，在关闭应用程序时警告用户
- 当 NapCatQQ 安装配置文件夹缺失时，阻止添加机器人

优化:
- 优化标题栏关闭按钮处理程序，使其始终使用新的关闭逻辑

杂项:
- 将 napcat_config_path 添加到 PathFunc 中，用于安装文件夹验证

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce user prompts and installation checks to improve bot management safety

New Features:
- Warn users when closing the application if bots are still running
- Prevent adding bots when NapCatQQ installation config folder is missing

Enhancements:
- Streamline the title bar close button handler to consistently use the new close logic

Chores:
- Add napcat_config_path to PathFunc for installation folder verification

</details>