### PR TITLE
fix: 修复QQ下载链接获取逻辑，从统一位置获取远程链接与版本

### DIFF
--- a/src/ui/window/guide_window/install_page.py
+++ b/src/ui/window/guide_window/install_page.py
@@ -23,6 +23,7 @@ from src.core.network.downloader import GithubDownloader, QQDownloader
 from src.core.network.urls import Urls
 from src.core.utils.install_func import NapCatInstall, QQInstall
 from src.core.utils.path_func import PathFunc
+from src.core.utils.get_version import GetRemoteVersionRunnable
 from src.ui.common.icon import NapCatDesktopIcon, StaticIcon
 from src.ui.components.info_bar import success_bar
 from src.ui.components.message_box import FolderBox
@@ -193,7 +194,11 @@ class InstallQQPage(InstallPageBase):
         """
         super().__init__(parent)
         # 创建杂七杂八的控件
-        self.url = self.get_download_url()
+        # self.url = self.get_download_url()
+        self.url = GetRemoteVersionRunnable().execute().qq_download_url
+        if self.url is None:
+            self.set_status_text(self.tr("获取 QQ 下载链接失败。"))
+        self.url = QUrl(self.url)
         self.file_path = it(PathFunc).tmp_path / self.url.fileName()
         self.downloader = QQDownloader(self.url)
 


### PR DESCRIPTION
修复了位于`src/ui/window/guide_window/install_page.py` `class InstallQQPage` 中获取QQ下载链接未能从统一位置获取的问题，此组件获取url方法仍使用旧版本且未使用统一组件获取远程链接

## Sourcery 总结

错误修复：
- 使用 `GetRemoteVersionRunnable` 来获取 QQ 下载 URL，而不是已废弃的 `get_download_url` 方法，并通过显示错误状态来处理缺失的 URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Use the GetRemoteVersionRunnable to fetch the QQ download URL instead of the deprecated get_download_url method and handle missing URLs by displaying an error status.

</details>