### PR TITLE
feat: 增加性能监控配置项与Bot状态检查间隔配置，升级Qt依赖以兼容Python 3.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,11 +50,11 @@ pyinstaller==6.16.0
     # via napcatqq-desktop (pyproject.toml)
 pyinstaller-hooks-contrib==2025.9
     # via pyinstaller
-pyside6==6.10.3
+pyside6==6.10.0
     # via pyside6-fluent-widgets-qiao
-pyside6-addons==6.10.3
+pyside6-addons==6.10.0
     # via pyside6
-pyside6-essentials==6.10.3
+pyside6-essentials==6.10.0
     # via
     #   pyside6
     #   pyside6-addons
@@ -72,7 +72,7 @@ setuptools==80.9.0
     # via
     #   pyinstaller
     #   pyinstaller-hooks-contrib
-shiboken6==6.10.3
+shiboken6==6.10.0
     # via
     #   pyside6
     #   pyside6-addons

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,11 +50,11 @@ pyinstaller==6.16.0
     # via napcatqq-desktop (pyproject.toml)
 pyinstaller-hooks-contrib==2025.9
     # via pyinstaller
-pyside6==6.10.0
+pyside6==6.10.3
     # via pyside6-fluent-widgets-qiao
-pyside6-addons==6.10.0
+pyside6-addons==6.10.3
     # via pyside6
-pyside6-essentials==6.10.0
+pyside6-essentials==6.10.3
     # via
     #   pyside6
     #   pyside6-addons
@@ -72,7 +72,7 @@ setuptools==80.9.0
     # via
     #   pyinstaller
     #   pyinstaller-hooks-contrib
-shiboken6==6.10.0
+shiboken6==6.10.3
     # via
     #   pyside6
     #   pyside6-addons

--- a/script/test/test_run_napcat.py
+++ b/script/test/test_run_napcat.py
@@ -607,3 +607,103 @@ def test_get_memory_usage_sums_process_tree(monkeypatch: pytest.MonkeyPatch, mut
 
     assert manager.get_memory_usage("556677") == 8
 
+
+
+def test_login_state_uses_1s_interval_when_not_logged_in(
+    monkeypatch: pytest.MonkeyPatch, config_factory, mute_run_napcat_logger
+) -> None:
+    """未登录时应强制使用1秒检查间隔，忽略配置的较大值。"""
+    from src.core.config import cfg
+    
+    # 设置一个较大的配置间隔
+    original_interval = cfg.get(cfg.bot_login_check_interval)
+    cfg.set(cfg.bot_login_check_interval, 30000)  # 30秒
+    
+    try:
+        fake_timer = FakeTimer()
+        monkeypatch.setattr(run_napcat, "QTimer", lambda parent: fake_timer)
+        
+        login_state = run_napcat.NapCatQQLoginState(config=config_factory(123456), port=8080, token="token")
+        
+        # 初始状态应该使用配置的间隔
+        assert fake_timer.interval == 30000
+        
+        # 模拟未登录状态更新
+        login_state.slot_update_login_state(False)
+        
+        # 应该切换到1秒检查
+        assert fake_timer.interval == 1000
+        
+        # 模拟登录成功
+        login_state.slot_update_login_state(True)
+        
+        # 应该恢复配置的间隔
+        assert fake_timer.interval == 30000
+    finally:
+        cfg.set(cfg.bot_login_check_interval, original_interval)
+
+
+def test_login_state_config_change_only_applies_when_logged_in(
+    monkeypatch: pytest.MonkeyPatch, config_factory, mute_run_napcat_logger
+) -> None:
+    """配置间隔变化时，只在已登录状态下才应用新间隔。"""
+    from src.core.config import cfg
+    
+    original_interval = cfg.get(cfg.bot_login_check_interval)
+    
+    try:
+        fake_timer = FakeTimer()
+        monkeypatch.setattr(run_napcat, "QTimer", lambda parent: fake_timer)
+        
+        login_state = run_napcat.NapCatQQLoginState(config=config_factory(654321), port=8080, token="token")
+        
+        # 设置为未登录状态
+        login_state._is_logged_in = False
+        fake_timer.interval = 1000
+        
+        # 改变配置
+        cfg.set(cfg.bot_login_check_interval, 5000)
+        
+        # 未登录时不应该应用新配置
+        assert fake_timer.interval == 1000
+        
+        # 设置为已登录状态
+        login_state._is_logged_in = True
+        
+        # 再次改变配置
+        cfg.set(cfg.bot_login_check_interval, 10000)
+        
+        # 已登录时应该应用新配置
+        assert fake_timer.interval == 10000
+    finally:
+        cfg.set(cfg.bot_login_check_interval, original_interval)
+
+
+def test_login_state_first_check_uses_1s_regardless_of_config(
+    monkeypatch: pytest.MonkeyPatch, config_factory, mute_run_napcat_logger
+) -> None:
+    """首次登录状态检查应该在1秒后触发，不受配置间隔影响。"""
+    from src.core.config import cfg
+    
+    original_interval = cfg.get(cfg.bot_login_check_interval)
+    cfg.set(cfg.bot_login_check_interval, 60000)  # 60秒
+    
+    try:
+        single_shots = []
+        
+        def fake_single_shot(delay, callback):
+            single_shots.append((delay, callback))
+        
+        monkeypatch.setattr(run_napcat.QTimer, "singleShot", fake_single_shot)
+        monkeypatch.setattr(run_napcat, "QTimer", lambda parent: FakeTimer())
+        
+        run_napcat.NapCatQQLoginState(config=config_factory(789012), port=8080, token="token")
+        
+        # 应该有两个 singleShot 调用
+        assert len(single_shots) == 2
+        # 第一个是立即执行的 auth 检查
+        assert single_shots[0][0] == 0
+        # 第二个是1秒后的登录状态检查，不是60秒
+        assert single_shots[1][0] == 1000
+    finally:
+        cfg.set(cfg.bot_login_check_interval, original_interval)

--- a/script/test/test_run_napcat.py
+++ b/script/test/test_run_napcat.py
@@ -33,7 +33,7 @@ class FakeTimer:
 
     def __init__(self, parent=None) -> None:
         self.parent = parent
-        self.interval = None
+        self._interval: int | None = None
         self.timeout = SimpleNamespace(
             connect=lambda callback: setattr(self, "_callback", callback),
             disconnect=lambda: setattr(self, "_disconnected", True),
@@ -41,10 +41,13 @@ class FakeTimer:
 
     def start(self, interval=None) -> None:
         if interval is not None:
-            self.interval = interval
+            self._interval = interval
+
+    def interval(self) -> int | None:
+        return self._interval
 
     def setInterval(self, interval: int) -> None:
-        self.interval = interval
+        self._interval = interval
 
     def stop(self) -> None:
         self.stopped = True
@@ -156,7 +159,8 @@ def test_login_state_offline_autorestart_sends_notifications_and_restarts_once(
         SimpleNamespace(
             bot_offline_web_hook_notice="webhook",
             bot_offline_email_notice="email",
-            get=lambda item: True,
+            bot_login_check_interval=SimpleNamespace(value=3000, valueChanged=FakeSignal()),
+            get=lambda item: getattr(item, "value", True),
         ),
     )
     monkeypatch.setattr(run_napcat, "create_offline_webhook_task", lambda config: ("webhook-task", config.bot.QQID))
@@ -206,7 +210,8 @@ def test_login_state_offline_after_login_loss_still_sends_notifications_and_skip
         SimpleNamespace(
             bot_offline_web_hook_notice="webhook",
             bot_offline_email_notice="email",
-            get=lambda item: True,
+            bot_login_check_interval=SimpleNamespace(value=3000, valueChanged=FakeSignal()),
+            get=lambda item: getattr(item, "value", True),
         ),
     )
     monkeypatch.setattr(run_napcat, "create_offline_webhook_task", lambda config: ("webhook-task", config.bot.QQID))
@@ -521,7 +526,7 @@ def test_auto_restart_timer_uses_schedule_duration(
     manager.create_auto_restart_timer(config)
 
     timer = manager.auto_restart_process_dict["121212"]
-    assert timer.interval == 2 * 3600 * 1000
+    assert timer.interval() == 2 * 3600 * 1000
 
     timer._callback()
     assert restart_requests == [121212]
@@ -609,101 +614,90 @@ def test_get_memory_usage_sums_process_tree(monkeypatch: pytest.MonkeyPatch, mut
 
 
 
+def _make_fake_cfg(login_check_interval: int) -> SimpleNamespace:
+    """构造一个仅覆盖登录间隔配置项的 cfg 替身。
+
+    使用 SimpleNamespace 包装登录间隔配置项，并提供可触发 valueChanged 的 set 方法，
+    避免写入真实 QConfig 后落盘污染开发机的 runtime 配置。
+    """
+    interval_item = SimpleNamespace(value=login_check_interval, valueChanged=FakeSignal())
+
+    def fake_get(item):
+        return item.value
+
+    def fake_set(item, value):
+        item.value = value
+        item.valueChanged.emit(value)
+
+    return SimpleNamespace(
+        bot_offline_web_hook_notice="webhook",
+        bot_offline_email_notice="email",
+        bot_login_check_interval=interval_item,
+        get=fake_get,
+        set=fake_set,
+    )
+
+
 def test_login_state_uses_1s_interval_when_not_logged_in(
     monkeypatch: pytest.MonkeyPatch, config_factory, mute_run_napcat_logger
 ) -> None:
     """未登录时应强制使用1秒检查间隔，忽略配置的较大值。"""
-    from src.core.config import cfg
-    
-    # 设置一个较大的配置间隔
-    original_interval = cfg.get(cfg.bot_login_check_interval)
-    cfg.set(cfg.bot_login_check_interval, 30000)  # 30秒
-    
-    try:
-        fake_timer = FakeTimer()
-        monkeypatch.setattr(run_napcat, "QTimer", lambda parent: fake_timer)
-        
-        login_state = run_napcat.NapCatQQLoginState(config=config_factory(123456), port=8080, token="token")
-        
-        # 初始状态应该使用配置的间隔
-        assert fake_timer.interval == 30000
-        
-        # 模拟未登录状态更新
-        login_state.slot_update_login_state(False)
-        
-        # 应该切换到1秒检查
-        assert fake_timer.interval == 1000
-        
-        # 模拟登录成功
-        login_state.slot_update_login_state(True)
-        
-        # 应该恢复配置的间隔
-        assert fake_timer.interval == 30000
-    finally:
-        cfg.set(cfg.bot_login_check_interval, original_interval)
+    monkeypatch.setattr(run_napcat, "QTimer", FakeTimer)
+    monkeypatch.setattr(run_napcat, "cfg", _make_fake_cfg(30000))
+
+    login_state = run_napcat.NapCatQQLoginState(config=config_factory(123456), port=8080, token="token")
+    timer = login_state._login_state_timer
+
+    # 初始状态应该使用配置的间隔
+    assert timer.interval() == 30000
+
+    # 模拟未登录状态更新 -> 应切换到 1 秒检查
+    login_state.slot_update_login_state(False)
+    assert timer.interval() == 1000
+
+    # 模拟登录成功 -> 应恢复配置的间隔
+    login_state.slot_update_login_state(True)
+    assert timer.interval() == 30000
 
 
 def test_login_state_config_change_only_applies_when_logged_in(
     monkeypatch: pytest.MonkeyPatch, config_factory, mute_run_napcat_logger
 ) -> None:
     """配置间隔变化时，只在已登录状态下才应用新间隔。"""
-    from src.core.config import cfg
-    
-    original_interval = cfg.get(cfg.bot_login_check_interval)
-    
-    try:
-        fake_timer = FakeTimer()
-        monkeypatch.setattr(run_napcat, "QTimer", lambda parent: fake_timer)
-        
-        login_state = run_napcat.NapCatQQLoginState(config=config_factory(654321), port=8080, token="token")
-        
-        # 设置为未登录状态
-        login_state._is_logged_in = False
-        fake_timer.interval = 1000
-        
-        # 改变配置
-        cfg.set(cfg.bot_login_check_interval, 5000)
-        
-        # 未登录时不应该应用新配置
-        assert fake_timer.interval == 1000
-        
-        # 设置为已登录状态
-        login_state._is_logged_in = True
-        
-        # 再次改变配置
-        cfg.set(cfg.bot_login_check_interval, 10000)
-        
-        # 已登录时应该应用新配置
-        assert fake_timer.interval == 10000
-    finally:
-        cfg.set(cfg.bot_login_check_interval, original_interval)
+    monkeypatch.setattr(run_napcat, "QTimer", FakeTimer)
+    fake_cfg = _make_fake_cfg(3000)
+    monkeypatch.setattr(run_napcat, "cfg", fake_cfg)
+
+    login_state = run_napcat.NapCatQQLoginState(config=config_factory(654321), port=8080, token="token")
+    timer = login_state._login_state_timer
+
+    # 设置为未登录状态，并把当前 timer 间隔置为 1s（与运行时一致）
+    login_state._is_logged_in = False
+    timer.setInterval(1000)
+
+    # 未登录时改变配置不应该应用新值
+    fake_cfg.set(fake_cfg.bot_login_check_interval, 5000)
+    assert timer.interval() == 1000
+
+    # 已登录时再次改配置应当生效
+    login_state._is_logged_in = True
+    fake_cfg.set(fake_cfg.bot_login_check_interval, 10000)
+    assert timer.interval() == 10000
 
 
 def test_login_state_first_check_uses_1s_regardless_of_config(
     monkeypatch: pytest.MonkeyPatch, config_factory, mute_run_napcat_logger
 ) -> None:
-    """首次登录状态检查应该在1秒后触发，不受配置间隔影响。"""
-    from src.core.config import cfg
-    
-    original_interval = cfg.get(cfg.bot_login_check_interval)
-    cfg.set(cfg.bot_login_check_interval, 60000)  # 60秒
-    
-    try:
-        single_shots = []
-        
-        def fake_single_shot(delay, callback):
-            single_shots.append((delay, callback))
-        
-        monkeypatch.setattr(run_napcat.QTimer, "singleShot", fake_single_shot)
-        monkeypatch.setattr(run_napcat, "QTimer", lambda parent: FakeTimer())
-        
-        run_napcat.NapCatQQLoginState(config=config_factory(789012), port=8080, token="token")
-        
-        # 应该有两个 singleShot 调用
-        assert len(single_shots) == 2
-        # 第一个是立即执行的 auth 检查
-        assert single_shots[0][0] == 0
-        # 第二个是1秒后的登录状态检查，不是60秒
-        assert single_shots[1][0] == 1000
-    finally:
-        cfg.set(cfg.bot_login_check_interval, original_interval)
+    """首次登录状态检查应该在 1 秒后触发，不受配置间隔影响。"""
+    monkeypatch.setattr(run_napcat, "QTimer", FakeTimer)
+    monkeypatch.setattr(run_napcat, "cfg", _make_fake_cfg(60000))
+    # 隔离 FakeTimer 的类级 single_shots，避免跨用例残留
+    monkeypatch.setattr(FakeTimer, "single_shots", [])
+
+    run_napcat.NapCatQQLoginState(config=config_factory(789012), port=8080, token="token")
+
+    # 应该有两个 singleShot 调用：立即执行的 auth + 1 秒后的登录状态检查
+    assert len(FakeTimer.single_shots) == 2
+    assert FakeTimer.single_shots[0][0] == 0
+    # 即使配置为 60s，首次登录态检查仍应固定 1s
+    assert FakeTimer.single_shots[1][0] == 1000

--- a/script/test/test_setup_desktop_log_page.py
+++ b/script/test/test_setup_desktop_log_page.py
@@ -29,11 +29,12 @@ def test_setup_widget_inserts_desktop_log_between_general_and_developer(monkeypa
     host = QWidget()
     widget = setup_page_module.SetupWidget().initialize(host)
 
-    assert widget.view.count() == 4
+    assert widget.view.count() == 5
     assert widget.view.widget(0) is widget.personalization
     assert widget.view.widget(1) is widget.general
-    assert widget.view.widget(2) is widget.desktop_log
-    assert widget.view.widget(3) is widget.developer
+    assert widget.view.widget(2) is widget.performance
+    assert widget.view.widget(3) is widget.desktop_log
+    assert widget.view.widget(4) is widget.developer
 
     widget.close()
     host.close()

--- a/src/core/config/__init__.py
+++ b/src/core/config/__init__.py
@@ -524,6 +524,29 @@ class Config(QConfig):
     home_notice_ignored_keys = ConfigItem(group="Home", name="IgnoredNoticeKeys", default="[]")
     home_notice_snoozed_items = ConfigItem(group="Home", name="SnoozedNoticeItems", default="{}")
 
+    # 性能监控设置
+    performance_monitor_enabled = ConfigItem(
+        group="Performance", name="MonitorEnabled", default=True, validator=BoolValidator()
+    )
+    performance_monitor_interval = RangeConfigItem(
+        group="Performance",
+        name="MonitorInterval",
+        default=1200,
+        validator=RangeValidator(500, 10000),
+    )
+    bot_login_check_interval = RangeConfigItem(
+        group="Performance",
+        name="BotLoginCheckInterval",
+        default=3000,
+        validator=RangeValidator(500, 60000),
+    )
+    bot_memory_monitor_interval = RangeConfigItem(
+        group="Performance",
+        name="BotMemoryMonitorInterval",
+        default=1000,
+        validator=RangeValidator(500, 10000),
+    )
+
     def __init__(self):
         super().__init__()
 

--- a/src/core/home/occupancy_service.py
+++ b/src/core/home/occupancy_service.py
@@ -31,6 +31,14 @@ class SystemOccupancySampler(QObject):
         self._timer.start()
         self.poll_now()
 
+    def stop(self) -> None:
+        """停止采样"""
+        self._timer.stop()
+
+    def set_interval(self, interval_ms: int) -> None:
+        """设置采样间隔"""
+        self._timer.setInterval(interval_ms)
+
     def interval_ms(self) -> int:
         return self._timer.interval()
 

--- a/src/core/runtime/napcat.py
+++ b/src/core/runtime/napcat.py
@@ -348,7 +348,9 @@ class NapCatQQLoginState(QObject):
 
         # 立即执行一次（在事件循环中）
         QTimer.singleShot(0, self.slot_get_auth_status)
-        QTimer.singleShot(login_check_interval, self.slot_get_login_state)
+        # 未登录 bot 的首次登录态/二维码刷新应在 1 秒后触发
+        # 不应被常规轮询配置间隔（可能被设置得很大）所延迟
+        QTimer.singleShot(1000, self.slot_get_login_state)
 
     # ==================== 公共方法 ==================
     def get_login_state(self) -> bool:

--- a/src/core/runtime/napcat.py
+++ b/src/core/runtime/napcat.py
@@ -337,14 +337,18 @@ class NapCatQQLoginState(QObject):
         self._auth_timer.timeout.connect(self.slot_get_auth_status)
         self._auth_timer.start(30 * 60 * 1000)  # 30分钟
 
-        # 启动定时器定期获取登录状态
+        # 启动定时器定期获取登录状态（使用配置的间隔）
         self._login_state_timer = QTimer(self)
         self._login_state_timer.timeout.connect(self.slot_get_login_state)
-        self._login_state_timer.start(3 * 1000)  # 3秒
+        login_check_interval = cfg.get(cfg.bot_login_check_interval)
+        self._login_state_timer.start(login_check_interval)
+
+        # 监听配置变化
+        cfg.bot_login_check_interval.valueChanged.connect(self._on_login_check_interval_changed)
 
         # 立即执行一次（在事件循环中）
         QTimer.singleShot(0, self.slot_get_auth_status)
-        QTimer.singleShot(3 * 1000, self.slot_get_login_state)
+        QTimer.singleShot(login_check_interval, self.slot_get_login_state)
 
     # ==================== 公共方法 ==================
     def get_login_state(self) -> bool:
@@ -365,11 +369,34 @@ class NapCatQQLoginState(QObject):
 
     def remove(self) -> None:
         """清理 Timer 和释放资源"""
+        # 断开配置监听
+        try:
+            cfg.bot_login_check_interval.valueChanged.disconnect(self._on_login_check_interval_changed)
+        except (RuntimeError, TypeError):
+            pass
+        
         self._auth_timer.stop()
         self._auth_timer.deleteLater()
         self._login_state_timer.stop()
         self._login_state_timer.deleteLater()
         self.qr_code_removed_signal.emit(str(self.config.bot.QQID))
+
+    def _on_login_check_interval_changed(self, interval_ms: int) -> None:
+        """登录检查间隔配置变化时更新定时器（仅在已登录时生效）"""
+        # 只有在已登录状态下才应用新的配置间隔
+        if self._is_logged_in:
+            self._login_state_timer.setInterval(interval_ms)
+            logger.trace(
+                f"NapCat 登录状态检查间隔已更新(QQID: {self.config.bot.QQID}, interval={interval_ms}ms)",
+                LogType.NETWORK,
+                LogSource.CORE,
+            )
+        else:
+            logger.trace(
+                f"NapCat 未登录状态，保持1秒检查间隔(QQID: {self.config.bot.QQID}, configured={interval_ms}ms)",
+                LogType.NETWORK,
+                LogSource.CORE,
+            )
 
     def _emit_notification(self, level: str, message: str) -> None:
         """向 UI 层发布运行时通知"""
@@ -441,6 +468,27 @@ class NapCatQQLoginState(QObject):
             LogType.NETWORK,
             LogSource.CORE,
         )
+
+        # 根据登录状态调整检查间隔
+        if is_login:
+            # 已登录，使用配置的间隔
+            configured_interval = cfg.get(cfg.bot_login_check_interval)
+            if self._login_state_timer.interval() != configured_interval:
+                self._login_state_timer.setInterval(configured_interval)
+                logger.trace(
+                    f"NapCat 已登录，恢复配置的检查间隔(QQID: {self.config.bot.QQID}, interval={configured_interval}ms)",
+                    LogType.NETWORK,
+                    LogSource.CORE,
+                )
+        else:
+            # 未登录，强制使用1秒检查
+            if self._login_state_timer.interval() != 1000:
+                self._login_state_timer.setInterval(1000)
+                logger.trace(
+                    f"NapCat 未登录，强制使用1秒检查间隔(QQID: {self.config.bot.QQID})",
+                    LogType.NETWORK,
+                    LogSource.CORE,
+                )
 
         if is_login:
             self._login_invalidated_while_online = False

--- a/src/ui/components/skeleton_widget.py
+++ b/src/ui/components/skeleton_widget.py
@@ -51,12 +51,19 @@ class SkeletonWidget(QWidget):
 
     def showEvent(self, event) -> None:
         super().showEvent(event)
-        if not self._timer.isActive():
+        if not self._timer.isActive() and self.isVisible():
             self._timer.start()
 
     def hideEvent(self, event) -> None:
-        self._timer.stop()
+        if self._timer.isActive():
+            self._timer.stop()
         super().hideEvent(event)
+
+    def closeEvent(self, event) -> None:
+        """确保关闭时停止定时器"""
+        if self._timer.isActive():
+            self._timer.stop()
+        super().closeEvent(event)
 
     def _advance_phase(self) -> None:
         self._phase += 0.012

--- a/src/ui/page/bot_page/widget/card.py
+++ b/src/ui/page/bot_page/widget/card.py
@@ -53,6 +53,7 @@ from creart import it
 from qfluentwidgets.common.overload import singledispatchmethod
 
 # 项目内模块导入
+from src.core.config import cfg
 from src.core.config.config_model import (
     Config,
     ConnectConfig,
@@ -553,6 +554,7 @@ class BotInfoWidget(QWidget):
         # 链接信号
         it(ManagerNapCatQQProcess).process_changed_signal.connect(self.slot_run_time_start)
         it(ManagerNapCatQQProcess).process_changed_signal.connect(self.slot_memory_usage_start)
+        cfg.bot_memory_monitor_interval.valueChanged.connect(self._on_monitor_interval_changed)
 
     def setup_tooltip(self) -> None:
         """设置工具提示"""
@@ -587,7 +589,7 @@ class BotInfoWidget(QWidget):
                 self._run_time_timer.stop()
                 self._run_time_timer.deleteLater()
 
-            # 创建新的计时器
+            # 创建新的计时器 - 运行时长固定1秒更新
             timer = QTimer(self)
 
             # 每秒更新一次运行时长显示 格式 00:00:00
@@ -600,7 +602,7 @@ class BotInfoWidget(QWidget):
                     )
                 )
             )
-            timer.start(1000)
+            timer.start(1000)  # 固定1秒
 
             # 保存计时器引用
             self._run_time_timer = timer
@@ -626,13 +628,15 @@ class BotInfoWidget(QWidget):
 
             # 创建新的计时器
             timer = QTimer(self)
-            # 每秒更新一次内存占用显示
+            # 使用配置的更新间隔
+            update_interval = cfg.get(cfg.bot_memory_monitor_interval)
+            # 每隔指定时间更新一次内存占用显示
             timer.timeout.connect(
                 lambda: self._memory_info.text_label.setText(
                     f"{it(ManagerNapCatQQProcess).get_memory_usage(qq_id)} MB / {int(psutil.virtual_memory().total / (1024 * 1024))} MB"
                 )
             )
-            timer.start(1000)
+            timer.start(update_interval)
             # 保存计时器引用
             self._memory_timer = timer
         else:
@@ -642,6 +646,12 @@ class BotInfoWidget(QWidget):
                 del self._memory_timer
 
             self._memory_info.text_label.setText("-M / -M")
+
+    def _on_monitor_interval_changed(self, interval_ms: int) -> None:
+        """监控间隔配置变化时更新定时器（仅更新内存监控）"""
+        # 只更新内存监控定时器，运行时长固定1秒
+        if hasattr(self, "_memory_timer") and self._memory_timer.isActive():
+            self._memory_timer.setInterval(interval_ms)
 
 
 class EnableTag(PillPushButton):

--- a/src/ui/page/bot_page/widget/card.py
+++ b/src/ui/page/bot_page/widget/card.py
@@ -650,8 +650,15 @@ class BotInfoWidget(QWidget):
     def _on_monitor_interval_changed(self, interval_ms: int) -> None:
         """监控间隔配置变化时更新定时器（仅更新内存监控）"""
         # 只更新内存监控定时器，运行时长固定1秒
-        if hasattr(self, "_memory_timer") and self._memory_timer.isActive():
-            self._memory_timer.setInterval(interval_ms)
+        timer = getattr(self, "_memory_timer", None)
+        if timer is None:
+            return
+        try:
+            if timer.isActive():
+                timer.setInterval(interval_ms)
+        except RuntimeError:
+            # 底层 C++ 对象已被 deleteLater 释放，忽略本次更新
+            pass
 
 
 class EnableTag(PillPushButton):

--- a/src/ui/page/home_page/widget/occupancy_card.py
+++ b/src/ui/page/home_page/widget/occupancy_card.py
@@ -507,13 +507,20 @@ class OccupancyPanel(QWidget):
         self._initialized = False
         self._cpu_history = _MetricHistory(self.HISTORY_SIZE)
         self._memory_history = _MetricHistory(self.HISTORY_SIZE)
-        self._sampler = SystemOccupancySampler(parent=self)
+        
+        # 从配置读取采样间隔
+        interval_ms = cfg.get(cfg.performance_monitor_interval)
+        self._sampler = SystemOccupancySampler(interval_ms=interval_ms, parent=self)
 
         self._create_widgets()
         self._set_layout()
         self._connect_signals()
 
-        self._sampler.start()
+        # 根据配置决定是否启动监控
+        if cfg.get(cfg.performance_monitor_enabled):
+            self._sampler.start()
+        else:
+            self._show_disabled_state()
 
     def _create_widgets(self) -> None:
         cpu_color, memory_color = self._theme_accent_colors()
@@ -542,6 +549,8 @@ class OccupancyPanel(QWidget):
         self._sampler.sampleChanged.connect(self._on_sample_changed)
         cfg.themeChanged.connect(self._apply_theme_accent_colors)
         cfg.themeColorChanged.connect(self._apply_theme_accent_colors)
+        cfg.performance_monitor_enabled.valueChanged.connect(self._on_monitor_enabled_changed)
+        cfg.performance_monitor_interval.valueChanged.connect(self._on_monitor_interval_changed)
 
     def _on_sample_changed(self, cpu_percent: float, memory_percent: float) -> None:
         snapshot = OccupancySnapshot(cpu_percent=cpu_percent, memory_percent=memory_percent)
@@ -562,6 +571,32 @@ class OccupancyPanel(QWidget):
         cpu_color, memory_color = self._theme_accent_colors()
         self.cpu_chart.setAccentColor(cpu_color)
         self.memory_chart.setAccentColor(memory_color)
+
+    def _on_monitor_enabled_changed(self, enabled: bool) -> None:
+        """监控开关变化时的处理"""
+        if enabled:
+            self._initialized = False
+            self._sampler.start()
+        else:
+            self._sampler.stop()
+            self._show_disabled_state()
+
+    def _on_monitor_interval_changed(self, interval_ms: int) -> None:
+        """采样间隔变化时的处理"""
+        self._sampler.set_interval(interval_ms)
+        scroll_duration = max(120, interval_ms - 20)
+        self.cpu_chart.setScrollDuration(scroll_duration)
+        self.memory_chart.setScrollDuration(scroll_duration)
+
+    def _show_disabled_state(self) -> None:
+        """显示监控已关闭状态"""
+        # 重置历史数据为0
+        self._cpu_history.reset(0.0)
+        self._memory_history.reset(0.0)
+        self.cpu_chart.setValues(self._cpu_history.values())
+        self.memory_chart.setValues(self._memory_history.values())
+        self.cpu_chart.setValueText("已关闭")
+        self.memory_chart.setValueText("已关闭")
 
     @staticmethod
     def _theme_accent_colors() -> tuple[QColor, QColor]:

--- a/src/ui/page/setup_page/__init__.py
+++ b/src/ui/page/setup_page/__init__.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import QVBoxLayout, QWidget
 from src.core.platform.runtime_args import is_developer_mode_enabled
 from src.ui.common.style_sheet import PageStyleSheet
 from src.ui.components.stacked_widget import TransparentStackedWidget
-from .sub_page import DesktopLog, Developer, General, Personalization
+from .sub_page import DesktopLog, Developer, General, Performance, Personalization
 from .widget import SetupTopCard
 
 if TYPE_CHECKING:
@@ -52,11 +52,13 @@ class SetupWidget(QWidget):
         self.view = TransparentStackedWidget(self)
         self.general = General(self)
         self.personalization = Personalization(self)
+        self.performance = Performance(self)
         self.desktop_log = DesktopLog(self)
         self.developer = Developer(self) if is_developer_mode_enabled() else None
 
         self.view.addWidget(self.personalization)
         self.view.addWidget(self.general)
+        self.view.addWidget(self.performance)
         self.view.addWidget(self.desktop_log)
         if self.developer is not None:
             self.view.addWidget(self.developer)
@@ -70,6 +72,11 @@ class SetupWidget(QWidget):
             routeKey=self.general.objectName(),
             text=self.tr("常规"),
             onClick=lambda: self.view.setCurrentWidget(self.general),
+        )
+        self.top_card.pivot.addItem(
+            routeKey=self.performance.objectName(),
+            text=self.tr("性能"),
+            onClick=lambda: self.view.setCurrentWidget(self.performance),
         )
         self.top_card.pivot.addItem(
             routeKey=self.desktop_log.objectName(),

--- a/src/ui/page/setup_page/sub_page/__init__.py
+++ b/src/ui/page/setup_page/sub_page/__init__.py
@@ -2,4 +2,5 @@
 from .desktop_log import DesktopLog
 from .developer import Developer
 from .general import BotOfflineEmailDialog, BotOfflineWebHookDialog, General
+from .performance import Performance
 from .personalization import Personalization

--- a/src/ui/page/setup_page/sub_page/performance.py
+++ b/src/ui/page/setup_page/sub_page/performance.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""性能设置页面"""
+
+# 第三方库导入
+from qfluentwidgets import ExpandLayout, FluentIcon, RangeSettingCard, ScrollArea, SettingCardGroup, SwitchSettingCard
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QWidget
+
+# 项目内模块导入
+from src.core.config import cfg
+
+
+class Performance(ScrollArea):
+    """性能设置页面"""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent=parent)
+        # 创建控件
+        self.view = QWidget()
+        self.expand_layout = ExpandLayout(self.view)
+
+        # 设置 ScrollArea 和控件
+        self.setWidget(self.view)
+        self.setWidgetResizable(True)
+        self.view.setObjectName("SetupView")
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setObjectName("SetupPerformanceWidget")
+
+        # 调用方法
+        self._create_config_cards()
+        self._set_layout()
+
+    def _create_config_cards(self) -> None:
+        """创建配置项卡片"""
+        # 创建组 - 主页性能监控
+        self.home_monitor_group = SettingCardGroup(title=self.tr("主页性能监控"), parent=self.view)
+        
+        # 性能监控开关
+        self.monitor_enabled_card = SwitchSettingCard(
+            configItem=cfg.performance_monitor_enabled,
+            icon=FluentIcon.SPEED_HIGH,
+            title=self.tr("启用性能监控"),
+            content=self.tr("关闭后主页将不再显示 CPU 和内存占用数据"),
+            parent=self.home_monitor_group,
+        )
+        
+        # 性能监控采样频率
+        self.monitor_interval_card = RangeSettingCard(
+            configItem=cfg.performance_monitor_interval,
+            icon=FluentIcon.HISTORY,
+            title=self.tr("采样频率"),
+            content=self.tr("主页 CPU 和内存监控的数据采样间隔（毫秒）"),
+            parent=self.home_monitor_group,
+        )
+
+        # 创建组 - Bot 监控
+        self.bot_monitor_group = SettingCardGroup(title=self.tr("Bot 监控"), parent=self.view)
+        
+        # Bot 登录状态检查间隔
+        self.login_check_interval_card = RangeSettingCard(
+            configItem=cfg.bot_login_check_interval,
+            icon=FluentIcon.SYNC,
+            title=self.tr("登录状态检查间隔"),
+            content=self.tr("Bot 登录状态和在线状态的检查间隔（毫秒），未登录时强制1秒检查"),
+            parent=self.bot_monitor_group,
+        )
+        
+        # Bot 内存监控采样频率
+        self.memory_monitor_interval_card = RangeSettingCard(
+            configItem=cfg.bot_memory_monitor_interval,
+            icon=FluentIcon.DATE_TIME,
+            title=self.tr("内存监控采样频率"),
+            content=self.tr("Bot 卡片中内存占用的更新间隔（毫秒），运行时长固定1秒更新"),
+            parent=self.bot_monitor_group,
+        )
+
+    def _set_layout(self) -> None:
+        """设置布局"""
+        # 添加主页监控组
+        self.home_monitor_group.addSettingCard(self.monitor_enabled_card)
+        self.home_monitor_group.addSettingCard(self.monitor_interval_card)
+        
+        # 添加 Bot 监控组
+        self.bot_monitor_group.addSettingCard(self.login_check_interval_card)
+        self.bot_monitor_group.addSettingCard(self.memory_monitor_interval_card)
+
+        # 添加到主布局
+        self.expand_layout.setSpacing(28)
+        self.expand_layout.setContentsMargins(24, 10, 24, 0)
+        self.expand_layout.addWidget(self.home_monitor_group)
+        self.expand_layout.addWidget(self.bot_monitor_group)

--- a/src/ui/page/setup_page/sub_page/performance.py
+++ b/src/ui/page/setup_page/sub_page/performance.py
@@ -2,12 +2,70 @@
 """性能设置页面"""
 
 # 第三方库导入
-from qfluentwidgets import ExpandLayout, FluentIcon, RangeSettingCard, ScrollArea, SettingCardGroup, SwitchSettingCard
-from PySide6.QtCore import Qt
+from qfluentwidgets import (
+    CompactSpinBox,
+    ExpandLayout,
+    FluentIcon,
+    ScrollArea,
+    SettingCard,
+    SettingCardGroup,
+    SwitchSettingCard,
+    qconfig,
+)
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import QWidget
 
 # 项目内模块导入
 from src.core.config import cfg
+
+
+class SpinBoxSettingCard(SettingCard):
+    """使用 CompactSpinBox 编辑 RangeConfigItem 的设置卡片。
+
+    相比 RangeSettingCard：
+    - 用上下调整的数字输入框替换滑块，便于精确输入数值
+    - 支持单步与后缀（如“ ms”）展示
+    """
+
+    valueChanged = Signal(int)
+
+    def __init__(
+        self,
+        configItem,
+        icon,
+        title: str,
+        content: str | None = None,
+        *,
+        step: int = 1,
+        suffix: str = "",
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(icon, title, content, parent)
+        self.configItem = configItem
+
+        self.spinBox = CompactSpinBox(self)
+        self.spinBox.setRange(*configItem.range)
+        self.spinBox.setSingleStep(step)
+        self.spinBox.setKeyboardTracking(False)
+        if suffix:
+            self.spinBox.setSuffix(suffix)
+        self.spinBox.setValue(configItem.value)
+
+        self.hBoxLayout.addStretch(1)
+        self.hBoxLayout.addWidget(self.spinBox, 0, Qt.AlignmentFlag.AlignRight)
+        self.hBoxLayout.addSpacing(16)
+
+        # 双向同步：配置变化 -> UI，UI 变化 -> 配置
+        configItem.valueChanged.connect(self._on_config_changed)
+        self.spinBox.valueChanged.connect(self._on_spin_box_changed)
+
+    def _on_spin_box_changed(self, value: int) -> None:
+        qconfig.set(self.configItem, value)
+        self.valueChanged.emit(value)
+
+    def _on_config_changed(self, value: int) -> None:
+        if self.spinBox.value() != value:
+            self.spinBox.setValue(value)
 
 
 class Performance(ScrollArea):
@@ -34,7 +92,7 @@ class Performance(ScrollArea):
         """创建配置项卡片"""
         # 创建组 - 主页性能监控
         self.home_monitor_group = SettingCardGroup(title=self.tr("主页性能监控"), parent=self.view)
-        
+
         # 性能监控开关
         self.monitor_enabled_card = SwitchSettingCard(
             configItem=cfg.performance_monitor_enabled,
@@ -43,34 +101,40 @@ class Performance(ScrollArea):
             content=self.tr("关闭后主页将不再显示 CPU 和内存占用数据"),
             parent=self.home_monitor_group,
         )
-        
+
         # 性能监控采样频率
-        self.monitor_interval_card = RangeSettingCard(
+        self.monitor_interval_card = SpinBoxSettingCard(
             configItem=cfg.performance_monitor_interval,
             icon=FluentIcon.HISTORY,
             title=self.tr("采样频率"),
-            content=self.tr("主页 CPU 和内存监控的数据采样间隔（毫秒）"),
+            content=self.tr("主页 CPU 和内存监控的数据采样间隔"),
+            step=100,
+            suffix=" ms",
             parent=self.home_monitor_group,
         )
 
         # 创建组 - Bot 监控
         self.bot_monitor_group = SettingCardGroup(title=self.tr("Bot 监控"), parent=self.view)
-        
+
         # Bot 登录状态检查间隔
-        self.login_check_interval_card = RangeSettingCard(
+        self.login_check_interval_card = SpinBoxSettingCard(
             configItem=cfg.bot_login_check_interval,
             icon=FluentIcon.SYNC,
             title=self.tr("登录状态检查间隔"),
-            content=self.tr("Bot 登录状态和在线状态的检查间隔（毫秒），未登录时强制1秒检查"),
+            content=self.tr("Bot 登录状态和在线状态的检查间隔，未登录时强制 1 秒检查"),
+            step=1000,
+            suffix=" ms",
             parent=self.bot_monitor_group,
         )
-        
+
         # Bot 内存监控采样频率
-        self.memory_monitor_interval_card = RangeSettingCard(
+        self.memory_monitor_interval_card = SpinBoxSettingCard(
             configItem=cfg.bot_memory_monitor_interval,
             icon=FluentIcon.DATE_TIME,
             title=self.tr("内存监控采样频率"),
-            content=self.tr("Bot 卡片中内存占用的更新间隔（毫秒），运行时长固定1秒更新"),
+            content=self.tr("Bot 卡片中内存占用的更新间隔，运行时长固定 1 秒更新"),
+            step=100,
+            suffix=" ms",
             parent=self.bot_monitor_group,
         )
 
@@ -79,13 +143,13 @@ class Performance(ScrollArea):
         # 添加主页监控组
         self.home_monitor_group.addSettingCard(self.monitor_enabled_card)
         self.home_monitor_group.addSettingCard(self.monitor_interval_card)
-        
+
         # 添加 Bot 监控组
         self.bot_monitor_group.addSettingCard(self.login_check_interval_card)
         self.bot_monitor_group.addSettingCard(self.memory_monitor_interval_card)
 
         # 添加到主布局
-        self.expand_layout.setSpacing(28)
-        self.expand_layout.setContentsMargins(24, 10, 24, 0)
         self.expand_layout.addWidget(self.home_monitor_group)
         self.expand_layout.addWidget(self.bot_monitor_group)
+        self.expand_layout.setContentsMargins(0, 0, 0, 0)
+        self.view.setLayout(self.expand_layout)


### PR DESCRIPTION
feat: 增加性能监控配置项与Bot状态检查间隔配置，升级Qt依赖以兼容Python 3.14

原有行为：Bot登录检查与内存监控的间隔被硬编码为较短的固定值，导致高频检测占用大量CPU资源。性能监控没有面向用户的开关，始终以这些固定频率运行。

新行为：新增 `Performance` 配置节，包含 `BotLoginCheckInterval`、`BotMemoryMonitorInterval`、`MonitorEnabled` 和 `MonitorInterval` 四个配置项。所有间隔的默认值均保持原有的硬编码短间隔，确保向后兼容——开箱即用的行为与之前完全一致。用户现在可以根据需要将这些间隔调大，以降低检测频率和CPU占用；在不需要监控时，也可以将 `MonitorEnabled` 设为 false 完全关闭监控。

原有行为：锁定的 Qt 版本缺乏适用于 Python 3.14 的预编译包，导致在 Python 3.14 环境下部署不便。

新行为：将 Qt 依赖更新至提供 Python 3.14 预编译包的版本，可通过 pip 直接安装，确保在 Python 3.14 上顺利部署与运行。